### PR TITLE
Render prop 방식 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import { useRef } from "react";
+
 import Select from "./RenderProp";
 import type { OptionType } from "./type";
 import "./styles/select.css";
@@ -11,16 +13,17 @@ const options = [
 ];
 
 function App() {
+  const selectRef = useRef<HTMLDivElement>(null);
   const handleChange = (option: OptionType) => {
     console.log(`${option.name}: API /${option.id}`);
   };
 
   return (
     <div className="App">
-      <Select defaultOption={options[0]} onSelectChange={handleChange}>
+      <Select selectRef={selectRef} defaultOption={options[0]} onSelectChange={handleChange}>
         {({ isOpened, selectedOption, buttonProps, optionsProps, optionProps }) => {
           return (
-            <>
+            <div className="select" ref={selectRef}>
               <label className="select-label">Frontend: </label>
               <button className="select-button" {...buttonProps}>
                 {selectedOption.name}
@@ -39,7 +42,7 @@ function App() {
                   ))}
                 </ul>
               )}
-            </>
+            </div>
           );
         }}
       </Select>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import Select from "./RenderProp";
 import type { OptionType } from "./type";
 import "./styles/select.css";
+import focusOnButton from "./RenderProp/utils/focusOnButton";
 
 const options = [
   { id: "js", name: "JavaScript" },
@@ -14,13 +15,19 @@ const options = [
 
 function App() {
   const selectRef = useRef<HTMLDivElement>(null);
+  const handleSelectClose = () => focusOnButton(selectRef);
   const handleChange = (option: OptionType) => {
     console.log(`${option.name}: API /${option.id}`);
   };
 
   return (
     <div className="App">
-      <Select selectRef={selectRef} defaultOption={options[0]} onSelectChange={handleChange}>
+      <Select
+        selectRef={selectRef}
+        defaultOption={options[0]}
+        onSelectChange={handleChange}
+        onSelectClose={handleSelectClose}
+      >
         {({ isOpened, selectedOption, buttonProps, optionsProps, optionProps }) => {
           return (
             <div className="select" ref={selectRef}>

--- a/src/RenderProp/index.tsx
+++ b/src/RenderProp/index.tsx
@@ -32,10 +32,12 @@ type Props = {
   selectRef: React.RefObject<HTMLDivElement>;
   defaultOption: OptionType;
   onSelectChange: (option: OptionType) => void;
+  onSelectOpen?: () => void;
+  onSelectClose?: () => void;
 };
 
-function Select({ children, selectRef, defaultOption, onSelectChange }: Props) {
-  const { isOpened, toggle } = useToggle({});
+function Select({ children, selectRef, defaultOption, onSelectChange, onSelectOpen, onSelectClose }: Props) {
+  const { isOpened, toggle } = useToggle({ onOpen: onSelectOpen, onClose: onSelectClose });
   const { selectedOption, changeSelectedOption, handleOptionClick } = useSelectedOption({
     defaultOption,
     onSelectChange,

--- a/src/RenderProp/index.tsx
+++ b/src/RenderProp/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React from "react";
 
 import useToggle from "./hooks/useToggle";
 import useSelectedOption from "./hooks/useSelectedOption";
@@ -29,12 +29,12 @@ type ChildrenProps = {
 
 type Props = {
   children: (args: ChildrenProps) => JSX.Element;
+  selectRef: React.RefObject<HTMLDivElement>;
   defaultOption: OptionType;
   onSelectChange: (option: OptionType) => void;
 };
 
-function Select({ children, defaultOption, onSelectChange }: Props) {
-  const selectRef = useRef<HTMLDivElement>(null);
+function Select({ children, selectRef, defaultOption, onSelectChange }: Props) {
   const { isOpened, toggle } = useToggle({});
   const { selectedOption, changeSelectedOption, handleOptionClick } = useSelectedOption({
     defaultOption,
@@ -53,7 +53,7 @@ function Select({ children, defaultOption, onSelectChange }: Props) {
   if (!children || typeof children !== "function") return null;
 
   return (
-    <div className="select" ref={selectRef}>
+    <>
       {children({
         isOpened,
         selectedOption,
@@ -66,7 +66,7 @@ function Select({ children, defaultOption, onSelectChange }: Props) {
           onMouseEnter: handleMouseEnter,
         },
       })}
-    </div>
+    </>
   );
 }
 

--- a/src/RenderProp/utils/focusOnButton.ts
+++ b/src/RenderProp/utils/focusOnButton.ts
@@ -1,0 +1,9 @@
+const focusOnButton = (selectRef: React.RefObject<HTMLDivElement>) => {
+  selectRef.current?.childNodes.forEach((node: ChildNode) => {
+    if (node.nodeName !== "BUTTON" || !(node instanceof HTMLElement)) return;
+
+    node.focus();
+  });
+};
+
+export default focusOnButton;


### PR DESCRIPTION
# usage
```js
const options = [
  { id: "js", name: "JavaScript" },
  { id: "react", name: "ReactJS" },
  { id: "next", name: "NextJS" },
  { id: "html", name: "HTML" },
  { id: "css", name: "CSS" },
];

const selectRef = useRef<HTMLDivElement>(null);
const handleSelectClose = () => focusOnButton(selectRef);
const handleChange = (option: OptionType) => { console.log(`${option.name}: API /${option.id}`); };

<Select
  selectRef={selectRef}
  defaultOption={options[0]}
  onSelectChange={handleChange}
  onSelectClose={handleSelectClose}
>
  {({ isOpened, selectedOption, buttonProps, optionsProps, optionProps }) => {
    return (
      <div className="select" ref={selectRef}>
        <label className="select-label">Frontend: </label>
        <button className="select-button" {...buttonProps}>
          {selectedOption.name}
        </button>
        {isOpened && (
          <ul className="select-options" {...optionsProps}>
            {options.map((option: OptionType) => (
              <li
                key={option.id}
                className={`select-option${selectedOption.id === option.id ? " selected" : ""}`}
                data-id={option.id}
                {...optionProps}
              >
                {option.name}
              </li>
            ))}
          </ul>
        )}
      </div>
    );
  }}
</Select>
```
- ref를 prop으로 받도록 수정
- onSelectOpen, onSelectClose를 선택적으로 넘겨 받도록 수정